### PR TITLE
Hotfix

### DIFF
--- a/05/src/.gitignore
+++ b/05/src/.gitignore
@@ -10,3 +10,5 @@
 
 # own secret vars store.
 personal.auto.tfvars
+
+.external_modules/*

--- a/05/src/main.tf
+++ b/05/src/main.tf
@@ -48,15 +48,16 @@ resource "yandex_vpc_subnet" "develop" {
 }
 
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   env_name       = "marketing"
   network_id     = module.vpc_dev.network_id
+  security_group_ids = [yandex_vpc_security_group.test_develop.id]
   subnet_zones   = ["ru-central1-a"]
   subnet_ids     = [module.vpc_dev.subnet_id]
   instance_name  = "vm"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false
 
   metadata = {
     user-data          = data.template_file.cloudinit.rendered
@@ -69,15 +70,16 @@ module "marketing-vm" {
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   env_name       = "analytics"
   network_id     = module.vpc_dev.network_id
+  security_group_ids = [yandex_vpc_security_group.test_develop.id]
   subnet_zones   = ["ru-central1-a"]
   subnet_ids     = [module.vpc_dev.subnet_id]
   instance_name  = "vm"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false
 
   metadata = {
     user-data          = data.template_file.cloudinit.rendered

--- a/05/src/providers.tf
+++ b/05/src/providers.tf
@@ -2,6 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~> 0.112.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"
     }
   }
   required_version = ">=0.13"

--- a/05/src/vpc/main.tf
+++ b/05/src/vpc/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~> 0.112.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
admins@s1:~/terraform/05/src$ terraform plan
╷
│ Error: Module source has changed
│ 
│   on main.tf line 51, in module "marketing-vm":
│   51:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
│ 
│ The source address was changed since this module was installed. Run "terraform init" to install all modules required by this
│ configuration.
╵
╷
│ Error: Module source has changed
│ 
│   on main.tf line 73, in module "analytics-vm":
│   73:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
│ 
│ The source address was changed since this module was installed. Run "terraform init" to install all modules required by this
│ configuration.