### PR TITLE
hotfix

### DIFF
--- a/05/src/main.tf
+++ b/05/src/main.tf
@@ -47,16 +47,23 @@ resource "yandex_vpc_subnet" "develop" {
   v4_cidr_blocks = ["10.0.1.0/24"]
 }
 
+resource "yandex_vpc_security_group" "test_develop" {
+  name       = "test_develop"
+  network_id = yandex_vpc_network.develop.id
+  folder_id  = var.folder_id
+}
+
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   env_name       = "marketing"
   network_id     = module.vpc_dev.network_id
   subnet_zones   = ["ru-central1-a"]
   subnet_ids     = [module.vpc_dev.subnet_id]
+  security_group_ids = [yandex_vpc_security_group.test_develop.id]
   instance_name  = "vm"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false
 
   metadata = {
     user-data          = data.template_file.cloudinit.rendered
@@ -69,15 +76,16 @@ module "marketing-vm" {
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   env_name       = "analytics"
   network_id     = module.vpc_dev.network_id
   subnet_zones   = ["ru-central1-a"]
   subnet_ids     = [module.vpc_dev.subnet_id]
+  security_group_ids = [yandex_vpc_security_group.test_develop.id]
   instance_name  = "vm"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false
 
   metadata = {
     user-data          = data.template_file.cloudinit.rendered

--- a/05/src/providers.tf
+++ b/05/src/providers.tf
@@ -2,9 +2,14 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~> 0.112.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"
     }
   }
-  required_version = ">=0.13"
+  required_version = ">=1.5"
 }
 
 provider "yandex" {


### PR DESCRIPTION
ДО ИСПРАВЛЕНИЙ

admins@s1:~/terraform/05/src$ docker run --rm -v "$(pwd):/tflint" ghcr.io/terraform-linters/tflint --chdir /tflint
4 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on ../tflint/main.tf line 51:
  51:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on ../tflint/main.tf line 72:
  72:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on ../tflint/main.tf line 92:
  92: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on ../tflint/providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_required_providers.md


      _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.38 

terraform scan results:

Passed checks: 4, Failed checks: 4, Skipped checks: 0
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:71-90
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:50-69
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: marketing-vm
        File: /main.tf:50-69
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: analytics-vm
        File: /main.tf:71-90
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:71-90

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:71-90

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:50-69

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:50-69

                Code lines for this resource are too many. Please use IDE of your choice to review the file.

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: marketing-vm
        File: /main.tf:50-69
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: analytics-vm
        File: /main.tf:71-90
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision



ПОСЛЕ ИСПРАВЛЕНИЙ
admins@s1:~/terraform/05/src$ docker run --rm --tty --volume $(pwd):/tf --workdir /tf bridgecrew/checkov --download-external-modules true --directory /tf

       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By Prisma Cloud | version: 3.2.38 

terraform scan results:

Passed checks: 8, Failed checks: 0, Skipped checks: 0

Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:72-92
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:72-92
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:72-92
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:50-70
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:50-70
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/4d05fab828b1fcae16556a4d167134efca2fccf2/main.tf:24-73
        Calling File: /main.tf:50-70
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: marketing-vm
        File: /main.tf:50-70
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: analytics-vm
        File: /main.tf:72-92
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision


ВЫВОД TERRAFORM PLAN ПОСЛЕ ВСЕХ ИЗМЕНЕНИЙ

admins@s1:~/terraform/05/src$ terraform plan
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=dc5ea0467743a30343b351ef647e7ca32dcb5a75dba3860ca23f9a99861c5cea]
module.vpc_dev.yandex_vpc_network.network: Refreshing state... [id=enpfmena1n0u7gekhaq7]
module.analytics-vm.data.yandex_compute_image.my_image: Reading...
yandex_vpc_network.develop: Refreshing state... [id=enpdl3i7b7ms7s6v9o2n]
module.marketing-vm.data.yandex_compute_image.my_image: Reading...
module.marketing-vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd8c3t86dc563mtmnqce]
module.analytics-vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd8c3t86dc563mtmnqce]
yandex_vpc_subnet.develop: Refreshing state... [id=e9bghdl7for1bjk14e86]
module.vpc_dev.yandex_vpc_subnet.subnet: Refreshing state... [id=e9bt4hheiid0r5ntlf4f]
module.marketing-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmk7rvhtcebia9vnae9]
module.analytics-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmbboiv2th7lublquj4]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # yandex_vpc_security_group.test_develop will be created
  + resource "yandex_vpc_security_group" "test_develop" {
      + created_at = (known after apply)
      + folder_id  = "b1gc1ageg74i0l5bikkv"
      + id         = (known after apply)
      + labels     = (known after apply)
      + name       = "test_develop"
      + network_id = "enpdl3i7b7ms7s6v9o2n"
      + status     = (known after apply)
    }

  # module.analytics-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmbboiv2th7lublquj4"
        name                      = "analytics-vm-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.marketing-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmk7rvhtcebia9vnae9"
        name                      = "marketing-vm-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [] -> (known after apply)
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.